### PR TITLE
[32] feat: secure client websockets

### DIFF
--- a/.bruno/MinecraftServerStatus.yml
+++ b/.bruno/MinecraftServerStatus.yml
@@ -5,6 +5,9 @@ info:
 
 websocket:
   url: "{{address}}/{{base_route}}/minecraft-servers/5b721cc4-6404-455d-9b68-4811437ba977/status/ws"
+  headers:
+    - name: Sec-WebSocket-Protocol
+      value: "{{accessToken}}"
   message:
     type: json
     data: "{}"

--- a/src/main/java/eu/divum/divumbackend/security/JwtAuthenticationFilter.java
+++ b/src/main/java/eu/divum/divumbackend/security/JwtAuthenticationFilter.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -21,16 +22,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final UserJwtService userJwtService;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+    protected void doFilterInternal(HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain)
         throws ServletException, IOException {
+
+        String accessToken = null;
         String authHeader = request.getHeader("Authorization");
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+        String wsProtocolHeader = request.getHeader("Sec-WebSocket-Protocol");
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            accessToken = authHeader.replace("Bearer ", "");
+        } else if (wsProtocolHeader != null && !wsProtocolHeader.isEmpty()) {
+            accessToken = wsProtocolHeader;
+            response.setHeader("Sec-WebSocket-Protocol", accessToken);
+        }
+
+        if (accessToken == null) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        String token = authHeader.replace("Bearer ", "");
-        UserJwt jwt = userJwtService.parseToken(token);
+        UserJwt jwt = userJwtService.parseToken(accessToken);
 
         if (jwt == null || jwt.isExpired()) {
             filterChain.doFilter(request, response);


### PR DESCRIPTION
### BREAKING CHANGE:

Client websockets are secured using the user's JWT access token, but this has to be attached to the websocket's  `Sec-WebSocket-Protocol` header.

**Example using builtin javascript websockets:**
`const ws = new WebSocket("${environment.wsBaseUrl}/v1/minecraft-servers/sdgsdfg/status/ws", ["{accessToken}"]);`
The second argument accepts the access token and automatically attaches it to the `Sec-WebSocket-Protocol` header.